### PR TITLE
#163: .gitignore, ignore '/puppet/modules/' directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 # Ignore the following directories
 .vagrant
 /log/
+/puppet/modules/


### PR DESCRIPTION
Resolves #163.