### PR TITLE
#363: Replace 'configure_drush.pp' with 'puppet-drush'

### DIFF
--- a/puppet/environment/development/Puppetfile
+++ b/puppet/environment/development/Puppetfile
@@ -41,3 +41,13 @@ mod 'apache',
 mod 'firewalld',
   :git => 'git@github.com:crayfishx/puppet-firewalld.git',
   :ref => '2.1.0'
+
+## Install Module: puppet-composer (puppet-drush dependency)
+mod 'composer',
+  :git => 'git@github.com:willdurand/puppet-composer.git',
+  :ref => 'v1.1.1',
+
+## Install Module: puppet-drush
+mod 'drush',
+  :git => 'git@github.com:previousnext/puppet-drush',
+  :ref => '1.8.1',

--- a/puppet/environment/development/Puppetfile
+++ b/puppet/environment/development/Puppetfile
@@ -50,4 +50,4 @@ mod 'composer',
 ## Install Module: puppet-drush
 mod 'drush',
   :git => 'git@github.com:previousnext/puppet-drush',
-  :ref => '1.8.1'
+  :ref => '0.1.1'

--- a/puppet/environment/development/Puppetfile
+++ b/puppet/environment/development/Puppetfile
@@ -45,9 +45,9 @@ mod 'firewalld',
 ## Install Module: puppet-composer (puppet-drush dependency)
 mod 'composer',
   :git => 'git@github.com:willdurand/puppet-composer.git',
-  :ref => 'v1.1.1',
+  :ref => 'v1.1.1'
 
 ## Install Module: puppet-drush
 mod 'drush',
   :git => 'git@github.com:previousnext/puppet-drush',
-  :ref => '1.8.1',
+  :ref => '1.8.1'

--- a/puppet/environment/development/manifests/configure_drush.pp
+++ b/puppet/environment/development/manifests/configure_drush.pp
@@ -2,7 +2,7 @@
 $user = 'provisioner'
 
 ## define $PATH for all execs
-Exec {path => ['/usr/sbin/', '/usr/bin']}
+Exec {path => ['/usr/sbin/']}
 
 ## install, and enable drush
 class drush {
@@ -17,7 +17,7 @@ class drush {
 
     ## define drush alias
     exec {'drush-alias':
-        command => "echo 'alias drush="sudo /usr/local/bin/drush"' >> /home/${user}/.bashrc",
+        command => "echo 'alias drush=\'/usr/local/bin/drush\'' >> /home/${user}/.bashrc",
         refreshonly => true,
         notify => Exec['reload-bash-startup-config'],
     }

--- a/puppet/environment/development/manifests/configure_drush.pp
+++ b/puppet/environment/development/manifests/configure_drush.pp
@@ -14,3 +14,9 @@ class drush {
         version => '8',
     }
 }
+
+## constructor
+class constructor {
+    contain drush
+}
+include constructor

--- a/puppet/environment/development/manifests/configure_drush.pp
+++ b/puppet/environment/development/manifests/configure_drush.pp
@@ -1,3 +1,9 @@
+## variables
+$user = 'provisioner'
+
+## define $PATH for all execs
+Exec {path => ['/usr/sbin/']}
+
 ## install, and enable drush
 class drush {
     ## drush dependency
@@ -6,7 +12,21 @@ class drush {
     ## install drush
     drush::drush { 'drush':
         version    => '8',
-        target_dir => '/usr/bin'
+        target_dir => '/usr/bin',
+    }
+
+    ## define drush alias
+    exec {'drush-alias':
+        command => "echo 'alias drush="sudo /usr/local/bin/drush"' >> /home/${user}/.bashrc",
+        refreshonly => true,
+        notify => Exec['reload-bash-startup-config'],
+    }
+
+    ## reload bash startup files
+    exec {'reload-bash-startup-config':
+        command => 'source ~/.bashrc',
+        refreshonly => true,
+        provider => 'shell',
     }
 }
 

--- a/puppet/environment/development/manifests/configure_drush.pp
+++ b/puppet/environment/development/manifests/configure_drush.pp
@@ -4,57 +4,13 @@ Exec {path => ['/usr/bin/', '/usr/local/']}
 ## include puppet modules
 include wget
 
-## variables
-$drush_version = '8.0.0-rc4'
+## install, and enable drush
+class drush {
+    ## install composer: drush installation dependency
+    class { 'composer': }
 
-## manual 'wget' drush
-exec {'download-drush':
-  command => "wget https://github.com/drush-ops/drush/releases/download/${drush_version}/drush.phar",
-  cwd     => '/tmp',
-  notify  => Exec['test-drush-install'],
-}
-
-## test drush install
-exec {'test-drush-install':
-  command     => 'php drush.phar core-status',
-  cwd         => '/tmp',
-  refreshonly => true,
-  notify      => Exec['change-permission-drush'],
-}
-
-## change permission for 'drush.phar'
-exec {'change-permission-drush':
-  command     => 'chmod ug+x drush.phar',
-  cwd         => '/tmp',
-  refreshonly => true,
-  notify      => Exec['move-drush'],
-}
-
-## move drush anywhere on $PATH, as 'drush', instead of 'drush.phar'
-exec {'move-drush':
-  command     => 'mv drush.phar /usr/local/bin/drush',
-  cwd         => '/tmp',
-  refreshonly => true,
-  notify      => Exec['initialize-drush'],
-}
-
-## enrich the bash startup file with completion
-exec {'initialize-drush':
-  command     => '/usr/local/bin/drush init',
-  refreshonly => true,
-  notify      => Exec['drush-alias'],
-}
-
-## define drush alias
-exec {'drush-alias':
-  command => 'echo "alias drush=\"sudo /usr/local/bin/drush\"" >> /home/provisioner/.bashrc',
-  refreshonly => true,
-  notify => Exec['reload-bash-startup-config'],
-}
-
-## reload bash startup files
-exec {'reload-bash-startup-config':
-  command => 'source ~/.bashrc',
-  refreshonly => true,
-  provider => 'shell',
+    ## install drush
+    drush::drush { 'drush8':
+        version => '8',
+    }
 }

--- a/puppet/environment/development/manifests/configure_drush.pp
+++ b/puppet/environment/development/manifests/configure_drush.pp
@@ -1,14 +1,12 @@
-## define $PATH for all execs
-Exec {path => ['/usr/bin/', '/usr/local/']}
-
 ## install, and enable drush
 class drush {
     ## drush dependency
     include composer
 
     ## install drush
-    drush::drush { 'drush8':
-        version => '8',
+    drush::drush { 'drush':
+        version    => '8',
+        target_dir => '/usr/bin'
     }
 }
 

--- a/puppet/environment/development/manifests/configure_drush.pp
+++ b/puppet/environment/development/manifests/configure_drush.pp
@@ -2,7 +2,7 @@
 $user = 'provisioner'
 
 ## define $PATH for all execs
-Exec {path => ['/usr/sbin/']}
+Exec {path => ['/usr/sbin/', '/usr/bin']}
 
 ## install, and enable drush
 class drush {

--- a/puppet/environment/development/manifests/configure_drush.pp
+++ b/puppet/environment/development/manifests/configure_drush.pp
@@ -3,7 +3,7 @@ Exec {path => ['/usr/bin/', '/usr/local/']}
 
 ## install, and enable drush
 class drush {
-    ## install composer module: drush dependency
+    ## drush dependency
     include composer
 
     ## install drush

--- a/puppet/environment/development/manifests/configure_drush.pp
+++ b/puppet/environment/development/manifests/configure_drush.pp
@@ -1,9 +1,6 @@
 ## define $PATH for all execs
 Exec {path => ['/usr/bin/', '/usr/local/']}
 
-## include puppet modules
-include wget
-
 ## install, and enable drush
 class drush {
     ## install composer: drush installation dependency

--- a/puppet/environment/development/manifests/configure_drush.pp
+++ b/puppet/environment/development/manifests/configure_drush.pp
@@ -3,8 +3,8 @@ Exec {path => ['/usr/bin/', '/usr/local/']}
 
 ## install, and enable drush
 class drush {
-    ## install composer: drush installation dependency
-    class { 'composer': }
+    ## install composer module: drush dependency
+    include composer
 
     ## install drush
     drush::drush { 'drush8':


### PR DESCRIPTION
Resolves #363.  We've tested this manifest, via the following commands within the vagrant vm:

```bash
$ puppet module install willdurand/composer
$ puppet module install previousnext/drush
$ cd /vagrant/puppet/environment/development/manifest/
$ puppet apply configure_drush.pp
```

And, we were able to implement the `drush` command, afterwards.  However, the current internet connection is too slow to test a full `vagrant up` build.  So, we will keep the pull request open, until it is fully verified.