### PR TITLE
#482: Ensure 'redis_server' bash script has linux line endings

### DIFF
--- a/puppet/environment/development/modules/redis/manifests/configure.pp
+++ b/puppet/environment/development/modules/redis/manifests/configure.pp
@@ -4,15 +4,24 @@
 ###
 class redis::configure {
     ## local variables
+    $root_dir          = '/vagrant'
     $template_path     = 'redis/server.erb'
     $build_environment = 'development'
     $script            = 'redis_server'
+    $environment_dir   = "${root_dir}/puppet/environment/${environment}"
 
     ## dos2unix systemd: convert clrf (windows to linux) in case host
     #                    machine is windows.
     file { '/etc/systemd/system/redis-systemd.service':
         ensure  => file,
         content => dos2unix(template($template_path)),
+    }
+
+    ## dos2unix bash script: convert clrf (windows to linux) in case host
+    #                    machine is windows.
+    file { "${environment_dir}/scripts/${script}":
+        ensure  => file,
+        content => dos2unix(file("${environment_dir}/scripts/${script}")),
         mode    => '770',
     }
 


### PR DESCRIPTION
Resolves #482.